### PR TITLE
Fix for 'random'

### DIFF
--- a/BS440.py
+++ b/BS440.py
@@ -63,7 +63,7 @@ def connect_device(address):
     device = None
     while not device_connected and tries > 0:
         try:
-            device = adapter.connect(address, 5, 'random')
+            device = adapter.connect(address, 5, pygatt.BLEAddressType.random)
             device_connected = True
         except pygatt.exceptions.NotConnectedError:
             tries -= 1


### PR DESCRIPTION
At least on my Archlinux system (no Raspberry Pi) I get the following error message:

File "/usr/lib/python2.7/site-packages/pygatt/backends/gatttool/gatttool.py", line 319, in connect
cmd = 'connect {0} {1}'.format(self._address, address_type.name)
AttributeError: 'str' object has no attribute 'name'

I took a look at the example in the pygatt repo and pygatt.BLEAddressType.random is used instead of 'random'
Exchanging it resolves the error for me.