### PR TITLE
Load plugins from config file

### DIFF
--- a/BS440.ini
+++ b/BS440.ini
@@ -16,4 +16,6 @@ device_model: BS440
 [Program]
 loglevel: debug
 logfile: BS440.log
-
+# Enable your plugins here, use the comma separated basename from the plugins/
+# Example:
+# plugins: BS440csv, BS440mail

--- a/BS440.py
+++ b/BS440.py
@@ -209,13 +209,21 @@ logging.basicConfig(level=numeric_level,
                     filemode='w')
 log = logging.getLogger(__name__)
 
-# Search for plugins in subdir "plugins" with name BS440*.py
-sys.path.insert(0, path)
-for f in os.listdir(path):
-    fname, ext = os.path.splitext(f)
-    if ext == '.py' and fname.startswith('BS440'):
-        mod = __import__(fname)
-        plugins[fname] = mod.Plugin()
+# Load configured plugins
+
+if config.has_option('Program', 'plugins'):
+    config_plugins = config.get('Program', 'plugins').split(',')
+    config_plugins = [plugin.strip(' ') for plugin in config_plugins]
+    log.info('Configured plugins: %s' % ', '.join(config_plugins))
+
+    sys.path.insert(0, path)
+    for plugin in config_plugins:
+        log.info('Loading plugin: %s' % plugin)
+        mod = __import__(plugin)
+        plugins[plugin] = mod.Plugin()
+    log.info('All plugins loaded.')
+else:
+    log.info('No plugins configured.')
 sys.path.pop(0)
 
 ble_address = config.get('Scale', 'ble_address')


### PR DESCRIPTION
I believe it woujld be easier if there was a key in the main ini file with a list of enabled plugins.

With this PR, you can add a key `plugins` to the section `Program`:

```ini
[Program]
loglevel: debug
logfile: BS440.log
plugins: BS440csv, BS440mail
```

In my opinion this is easier to manage especially when you are testing out new/updated plugins.